### PR TITLE
Bug fix: Native elements visible through non-mounted slots.

### DIFF
--- a/pax-compiler/files/interfaces/web/src/classes/native-element-pool.ts
+++ b/pax-compiler/files/interfaces/web/src/classes/native-element-pool.ts
@@ -203,7 +203,7 @@ export class NativeElementPool {
             this.layers.addElement(textboxDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, textboxDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("chassi: undefined id or occlusionLayer");
         }
 
     }
@@ -310,7 +310,7 @@ export class NativeElementPool {
             this.layers.addElement(radioSetDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, radioSetDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("undefined id or occlusionLayer");
         }
 
     }
@@ -405,7 +405,7 @@ export class NativeElementPool {
             this.layers.addElement(sliderDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, sliderDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("undefined id or occlusionLayer");
         }
 
     }
@@ -475,7 +475,7 @@ export class NativeElementPool {
             this.layers.addElement(textboxDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, textboxDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("undefined id or occlusionLayer");
         }
 
     }
@@ -560,7 +560,7 @@ export class NativeElementPool {
             this.layers.addElement(buttonDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, buttonDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("undefined id or occlusionLayer");
         }
     }
 
@@ -640,7 +640,7 @@ export class NativeElementPool {
             this.layers.addElement(textDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, textDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("undefined id or occlusionLayer");
         }
     }
 
@@ -751,11 +751,13 @@ export class NativeElementPool {
 
     textDelete(id: number) {
         let oldNode = this.nodesLookup.get(id);
-        this.resizeObserver.unobserve(oldNode!);
         if (oldNode){
+            this.resizeObserver.unobserve(oldNode!);
             let parent = oldNode.parentElement;
             parent!.removeChild(oldNode);
             this.nodesLookup.delete(id);
+        } else {
+            console.warn("chassi: tried to delete non-existent text");
         }
     }
 
@@ -815,7 +817,7 @@ export class NativeElementPool {
             this.layers.addElement(scrollerDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, scrollerDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("undefined id or occlusionLayer");
         }
     }
 
@@ -869,7 +871,8 @@ export class NativeElementPool {
     scrollerDelete(id: number){
         let oldNode = this.nodesLookup.get(id);
         if (oldNode == undefined) {
-            throw new Error("tried to delete non-existent scroller");
+            console.warn("tried to delete non-existent scroller");
+            return;
         }
         let parent = oldNode.parentElement!;
         parent.removeChild(oldNode);
@@ -890,7 +893,7 @@ export class NativeElementPool {
             this.layers.addElement(eventBlockerDiv, patch.parentFrame, patch.occlusionLayerId);
             this.nodesLookup.set(patch.id!, eventBlockerDiv);
         } else {
-            throw new Error("undefined id or occlusionLayer");
+            console.warn("undefined id or occlusionLayer");
         }
 
 
@@ -899,7 +902,8 @@ export class NativeElementPool {
     eventBlockerUpdate(patch: EventBlockerUpdatePatch){
         let leaf = this.nodesLookup.get(patch.id!);
         if (leaf == undefined) {
-            throw new Error("tried to update non-existent event blocker");
+            console.warn("tried to update non-existent event blocker");
+            return;
         }
         // Handle size_x and size_y
         if (patch.sizeX != null) {
@@ -917,7 +921,8 @@ export class NativeElementPool {
     eventBlockerDelete(id: number){
         let oldNode = this.nodesLookup.get(id);
         if (oldNode == undefined) {
-            throw new Error("tried to delete non-existent event blocker");
+            console.warn("tried to delete non-existent event blocker");
+            return;
         }
         let parent = oldNode.parentElement!;
         parent.removeChild(oldNode);
@@ -983,7 +988,8 @@ function toCssColor(color: ColorGroup): string {
         let p = color.Rgba;
         return `rgba(${p[0] * 255},${p[1] * 255},${p[2] * 255},${p[3]})`; //Note that alpha channel expects [0.0, 1.0] in CSS
     } else {
-        throw new TypeError("Unsupported Color Format");
+        console.warn("chassi: Unsupported Color Format");
+        return "magenta";
     }        
 }
 

--- a/pax-designer/src/lib.rs
+++ b/pax-designer/src/lib.rs
@@ -80,16 +80,10 @@ impl PaxDesigner {
         let ctx = ctx.clone();
         let deps = [manifest_load_state.untyped()];
         self.manifest_loaded_from_server
-            .replace_with(Property::computed(
-                move || {
-                    manifest_load_state.get()
-                },
-                &deps,
-            ));
+            .replace_with(Property::computed(move || manifest_load_state.get(), &deps));
     }
 
     pub fn tick(&mut self, ctx: &NodeContext) {
-
         if ctx.frames_elapsed.get() == 1 {
             // when manifests load, set transform of glass to fit scene
             model::read_app_state(|app_state| {
@@ -107,9 +101,10 @@ impl PaxDesigner {
                         (stage.width as f64 / 2.0),
                         (stage.height as f64 / 2.0),
                     )) * Transform2::scale(1.4)
-                        * Transform2::<math::coordinate_spaces::Glass>::translate(
-                            -Vector2::new(w / 2.0, h / 2.0),
-                        ),
+                        * Transform2::<math::coordinate_spaces::Glass>::translate(-Vector2::new(
+                            w / 2.0,
+                            h / 2.0,
+                        )),
                 );
             });
         }

--- a/pax-runtime/src/component.rs
+++ b/pax-runtime/src/component.rs
@@ -47,7 +47,7 @@ impl InstanceNode for ComponentInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-runtime/src/conditional.rs
+++ b/pax-runtime/src/conditional.rs
@@ -57,7 +57,7 @@ impl InstanceNode for ConditionalInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-runtime/src/rendering.rs
+++ b/pax-runtime/src/rendering.rs
@@ -128,12 +128,12 @@ pub trait InstanceNode {
         //no-op default implementation
     }
 
-    /// Fires during the tick when a node is first attached to the render tree.  For example,
+    /// Fires when a node is first attached to the (shadow) tree.  For example,
     /// this event fires by all nodes on the global first tick, and by all nodes in a subtree
     /// when a `Conditional` subsequently turns on a subtree (i.e. when the `Conditional`s criterion becomes `true` after being `false` through the end of at least 1 frame.)
-    /// A use-case: send a message to native renderers that a `Text` element should be rendered and tracked
+    /// A use-case: expand a for loops children
     #[allow(unused_variables)]
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,
@@ -148,6 +148,18 @@ pub trait InstanceNode {
             &expanded_node.parent_frame,
         );
         expanded_node.children.set(new_children);
+    }
+
+    /// Fires when a node is first attached to the render tree.  For example,
+    /// this event fires by all nodes on the global first tick, and by all nodes in a subtree except for slot_children of components
+    /// when a `Conditional` subsequently turns on a subtree (i.e. when the `Conditional`s criterion becomes `true` after being `false` through the end of at least 1 frame.)
+    /// A use-case: send a message to native renderers that a `Text` element should be rendered and tracked
+    #[allow(unused_variables)]
+    fn handle_render_mount(
+        self: Rc<Self>,
+        expanded_node: &Rc<ExpandedNode>,
+        context: &Rc<RuntimeContext>,
+    ) {
     }
 
     /// Fires during element unmount, when an element is about to be removed from the render tree (e.g. by a `Conditional`)

--- a/pax-runtime/src/repeat.rs
+++ b/pax-runtime/src/repeat.rs
@@ -106,7 +106,7 @@ impl InstanceNode for RepeatInstance {
 
     fn update(self: Rc<Self>, _expanded_node: &Rc<ExpandedNode>, _context: &Rc<RuntimeContext>) {}
 
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-runtime/src/slot.rs
+++ b/pax-runtime/src/slot.rs
@@ -52,7 +52,7 @@ impl InstanceNode for SlotInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/core/event_blocker.rs
+++ b/pax-std/src/core/event_blocker.rs
@@ -38,7 +38,7 @@ impl InstanceNode for EventBlockerInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/core/frame.rs
+++ b/pax-std/src/core/frame.rs
@@ -107,7 +107,7 @@ impl InstanceNode for FrameInstance {
         }
     }
 
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/core/image.rs
+++ b/pax-std/src/core/image.rs
@@ -57,7 +57,7 @@ impl InstanceNode for ImageInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/core/inline_frame.rs
+++ b/pax-std/src/core/inline_frame.rs
@@ -59,7 +59,11 @@ impl InstanceNode for InlineFrameInstance {
         &self.base
     }
 
-    fn handle_mount(self: Rc<Self>, expanded_node: &Rc<ExpandedNode>, ctx: &Rc<RuntimeContext>) {
+    fn handle_shadow_mount(
+        self: Rc<Self>,
+        expanded_node: &Rc<ExpandedNode>,
+        ctx: &Rc<RuntimeContext>,
+    ) {
         let instance_node = Rc::clone(&*borrow!(ctx.userland_frame_instance_node));
         let children_with_envs = vec![(
             instance_node,

--- a/pax-std/src/core/scrollbar.rs
+++ b/pax-std/src/core/scrollbar.rs
@@ -50,7 +50,7 @@ impl InstanceNode for ScrollbarInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/core/text.rs
+++ b/pax-std/src/core/text.rs
@@ -95,7 +95,7 @@ impl InstanceNode for TextInstance {
         }
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/drawing/path.rs
+++ b/pax-std/src/drawing/path.rs
@@ -71,7 +71,7 @@ impl InstanceNode for PathInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_shadow_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/forms/button.rs
+++ b/pax-std/src/forms/button.rs
@@ -68,7 +68,7 @@ impl InstanceNode for ButtonInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/forms/checkbox.rs
+++ b/pax-std/src/forms/checkbox.rs
@@ -62,7 +62,7 @@ impl InstanceNode for CheckboxInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/forms/dropdown.rs
+++ b/pax-std/src/forms/dropdown.rs
@@ -73,7 +73,7 @@ impl InstanceNode for DropdownInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/forms/radio_set.rs
+++ b/pax-std/src/forms/radio_set.rs
@@ -72,7 +72,7 @@ impl InstanceNode for RadioSetInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/forms/slider.rs
+++ b/pax-std/src/forms/slider.rs
@@ -63,7 +63,7 @@ impl InstanceNode for SliderInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/forms/textbox.rs
+++ b/pax-std/src/forms/textbox.rs
@@ -71,7 +71,7 @@ impl InstanceNode for TextboxInstance {
         })
     }
 
-    fn handle_mount(
+    fn handle_render_mount(
         self: Rc<Self>,
         expanded_node: &Rc<ExpandedNode>,
         context: &Rc<RuntimeContext>,

--- a/pax-std/src/layout/carousel.rs
+++ b/pax-std/src/layout/carousel.rs
@@ -42,8 +42,9 @@ impl Carousel {
 
                 let mut cell_specs = vec![];
                 for i in 0..slot_children_count {
-                    //let is_active = (i as isize) >= (current_cell as isize) - 1 && (i as isize) <= (current_cell as isize) + 1;
-                    let is_active = true;
+                    let is_active = (i as isize) >= (current_cell as isize) - 1
+                        && (i as isize) <= (current_cell as isize) + 1;
+                    // let is_active = true;
 
                     let x_percent = 50.0 + ((i as f64 * 100.0) - transition);
 


### PR DESCRIPTION
instance node handle_mount divided into two methods:
- handle_shadow_mount (updates for loop sources, etc. but no native message firing)
- handle_render_mount (fired once visible, sends native messages)

cleaned up some web chassis logic to log errors instead of panic-ing.