### PR TITLE
Mouse over/out events first pass

### DIFF
--- a/pax-chassis-common/src/core_graphics_c_bridge.rs
+++ b/pax-chassis-common/src/core_graphics_c_bridge.rs
@@ -65,32 +65,27 @@ pub extern "C" fn pax_interrupt(
     let interrupt = interrupt_wrapped.unwrap();
     match interrupt {
         NativeInterrupt::Click(args) => {
-            let prospective_hit = engine
+            let topmost_node = engine
                 .runtime_context
                 .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-            match prospective_hit {
-                Some(topmost_node) => {
-                    let modifiers = args
-                        .modifiers
-                        .iter()
-                        .map(|x| ModifierKey::from(x))
-                        .collect();
-                    let args_click = Click {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button),
-                            modifiers,
-                        },
-                    };
-                    topmost_node.dispatch_click(
-                        Event::new(args_click),
-                        &engine.runtime_context.globals(),
-                        &engine.runtime_context,
-                    );
-                }
-                _ => {}
+            let modifiers = args
+                .modifiers
+                .iter()
+                .map(|x| ModifierKey::from(x))
+                .collect();
+            let args_click = Click {
+                mouse: MouseEventArgs {
+                    x: args.x,
+                    y: args.y,
+                    button: MouseButton::from(args.button),
+                    modifiers,
+                },
             };
+            topmost_node.dispatch_click(
+                Event::new(args_click),
+                &engine.runtime_context.globals(),
+                &engine.runtime_context,
+            );
         }
         NativeInterrupt::Scrollbar(_args) => {}
         NativeInterrupt::Scroll(_args) => {}

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -31,8 +31,8 @@ pub use {console_error_panic_hook, console_log};
 use pax_message::NativeInterrupt;
 use pax_runtime::api::{
     Clap, Click, ContextMenu, DoubleClick, Drop, KeyDown, KeyPress, KeyUp, KeyboardEventArgs,
-    ModifierKey, MouseButton, MouseDown, MouseEventArgs, MouseMove, MouseOut, MouseOver, MouseUp,
-    Touch, TouchEnd, TouchMove, TouchStart, Wheel,
+    ModifierKey, MouseButton, MouseDown, MouseEventArgs, MouseMove, MouseUp, Touch, TouchEnd,
+    TouchMove, TouchStart, Wheel,
 };
 use serde_json;
 
@@ -191,28 +191,20 @@ impl PaxChassisWeb {
         let ctx = &engine.runtime_context;
         let globals = ctx.globals();
         let prevent_default = match &x {
-            NativeInterrupt::Focus(args) => engine.global_dispatch_focus(Focus {}),
+            NativeInterrupt::Focus(_args) => engine.global_dispatch_focus(Focus {}),
             NativeInterrupt::DropFile(args) => {
                 let data = Uint8Array::new(additional_payload).to_vec();
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_drop = Drop {
-                        x: args.x,
-                        y: args.y,
-                        name: args.name.clone(),
-                        mime_type: args.mime_type.clone(),
-                        data,
-                    };
-                    topmost_node.dispatch_drop(
-                        Event::new(args_drop),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let args_drop = Drop {
+                    x: args.x,
+                    y: args.y,
+                    name: args.name.clone(),
+                    mime_type: args.mime_type.clone(),
+                    data,
+                };
+                topmost_node.dispatch_drop(Event::new(args_drop), &globals, &engine.runtime_context)
             }
             NativeInterrupt::FormRadioSetChange(args) => {
                 let node = engine.get_expanded_node(pax_runtime::ExpandedNodeIdentifier(args.id));
@@ -329,30 +321,26 @@ impl PaxChassisWeb {
 
             NativeInterrupt::AddedLayer(_args) => false,
             NativeInterrupt::Click(args) => {
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_click = Click {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_click(
-                        Event::new(args_click),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let args_click = Click {
+                    mouse: MouseEventArgs {
+                        x: args.x,
+                        y: args.y,
+                        button: MouseButton::from(args.button.clone()),
+                        modifiers: args
+                            .modifiers
+                            .iter()
+                            .map(|x| ModifierKey::from(x))
+                            .collect(),
+                    },
+                };
+                topmost_node.dispatch_click(
+                    Event::new(args_click),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::Scrollbar(args) => {
                 let node = engine.get_expanded_node(pax_runtime::ExpandedNodeIdentifier(args.id));
@@ -363,73 +351,53 @@ impl PaxChassisWeb {
             }
             NativeInterrupt::Scroll(_) => false,
             NativeInterrupt::Clap(args) => {
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_clap = Clap {
-                        x: args.x,
-                        y: args.y,
-                    };
-                    topmost_node.dispatch_clap(
-                        Event::new(args_clap),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let args_clap = Clap {
+                    x: args.x,
+                    y: args.y,
+                };
+                topmost_node.dispatch_clap(Event::new(args_clap), &globals, &engine.runtime_context)
             }
             NativeInterrupt::TouchStart(args) => {
                 let first_touch = args.touches.get(0).unwrap();
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(first_touch.x, first_touch.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
-                    let args_touch_start = TouchStart { touches };
-                    topmost_node.dispatch_touch_start(
-                        Event::new(args_touch_start),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
+                let args_touch_start = TouchStart { touches };
+                topmost_node.dispatch_touch_start(
+                    Event::new(args_touch_start),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::TouchMove(args) => {
                 let first_touch = args.touches.get(0).unwrap();
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(first_touch.x, first_touch.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
-                    let args_touch_move = TouchMove { touches };
-                    topmost_node.dispatch_touch_move(
-                        Event::new(args_touch_move),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
+                let args_touch_move = TouchMove { touches };
+                topmost_node.dispatch_touch_move(
+                    Event::new(args_touch_move),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::TouchEnd(args) => {
                 let first_touch = args.touches.get(0).unwrap();
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(first_touch.x, first_touch.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
-                    let args_touch_end = TouchEnd { touches };
-                    topmost_node.dispatch_touch_end(
-                        Event::new(args_touch_end),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let touches = args.touches.iter().map(|x| Touch::from(x)).collect();
+                let args_touch_end = TouchEnd { touches };
+                topmost_node.dispatch_touch_end(
+                    Event::new(args_touch_end),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::KeyDown(args) => {
                 let modifiers = args
@@ -477,212 +445,136 @@ impl PaxChassisWeb {
                 engine.global_dispatch_key_press(args_key_press)
             }
             NativeInterrupt::DoubleClick(args) => {
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_double_click = DoubleClick {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_double_click(
-                        Event::new(args_double_click),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
-            }
-            NativeInterrupt::MouseMove(args) => {
-                let prospective_hit = engine
-                    .runtime_context
-                    .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_mouse_move = MouseMove {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_mouse_move(
-                        Event::new(args_mouse_move),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
-            }
-            NativeInterrupt::Wheel(args) => {
-                let prospective_hit = engine
-                    .runtime_context
-                    .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let modifiers = args
-                        .modifiers
-                        .iter()
-                        .map(|x| ModifierKey::from(x))
-                        .collect();
-                    let args_wheel = Wheel {
+                let args_double_click = DoubleClick {
+                    mouse: MouseEventArgs {
                         x: args.x,
                         y: args.y,
-                        delta_x: args.delta_x,
-                        delta_y: args.delta_y,
-                        modifiers,
-                    };
-                    topmost_node.dispatch_wheel(
-                        Event::new(args_wheel),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                        button: MouseButton::from(args.button.clone()),
+                        modifiers: args
+                            .modifiers
+                            .iter()
+                            .map(|x| ModifierKey::from(x))
+                            .collect(),
+                    },
+                };
+                topmost_node.dispatch_double_click(
+                    Event::new(args_double_click),
+                    &globals,
+                    &engine.runtime_context,
+                )
+            }
+            NativeInterrupt::MouseMove(args) => {
+                let topmost_node = engine
+                    .runtime_context
+                    .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
+                let args_mouse_move = MouseMove {
+                    mouse: MouseEventArgs {
+                        x: args.x,
+                        y: args.y,
+                        button: MouseButton::from(args.button.clone()),
+                        modifiers: args
+                            .modifiers
+                            .iter()
+                            .map(|x| ModifierKey::from(x))
+                            .collect(),
+                    },
+                };
+                topmost_node.dispatch_mouse_move(
+                    Event::new(args_mouse_move),
+                    &globals,
+                    &engine.runtime_context,
+                )
+            }
+            NativeInterrupt::Wheel(args) => {
+                let topmost_node = engine
+                    .runtime_context
+                    .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
+                let modifiers = args
+                    .modifiers
+                    .iter()
+                    .map(|x| ModifierKey::from(x))
+                    .collect();
+                let args_wheel = Wheel {
+                    x: args.x,
+                    y: args.y,
+                    delta_x: args.delta_x,
+                    delta_y: args.delta_y,
+                    modifiers,
+                };
+                topmost_node.dispatch_wheel(
+                    Event::new(args_wheel),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::MouseDown(args) => {
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_mouse_down = MouseDown {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_mouse_down(
-                        Event::new(args_mouse_down),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let args_mouse_down = MouseDown {
+                    mouse: MouseEventArgs {
+                        x: args.x,
+                        y: args.y,
+                        button: MouseButton::from(args.button.clone()),
+                        modifiers: args
+                            .modifiers
+                            .iter()
+                            .map(|x| ModifierKey::from(x))
+                            .collect(),
+                    },
+                };
+                topmost_node.dispatch_mouse_down(
+                    Event::new(args_mouse_down),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::MouseUp(args) => {
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_mouse_up = MouseUp {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_mouse_up(
-                        Event::new(args_mouse_up),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
-            }
-            NativeInterrupt::MouseOver(args) => {
-                let prospective_hit = engine
-                    .runtime_context
-                    .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_mouse_over = MouseOver {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_mouse_over(
-                        Event::new(args_mouse_over),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
-            }
-            NativeInterrupt::MouseOut(args) => {
-                let prospective_hit = engine
-                    .runtime_context
-                    .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_mouse_out = MouseOut {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_mouse_out(
-                        Event::new(args_mouse_out),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let args_mouse_up = MouseUp {
+                    mouse: MouseEventArgs {
+                        x: args.x,
+                        y: args.y,
+                        button: MouseButton::from(args.button.clone()),
+                        modifiers: args
+                            .modifiers
+                            .iter()
+                            .map(|x| ModifierKey::from(x))
+                            .collect(),
+                    },
+                };
+                topmost_node.dispatch_mouse_up(
+                    Event::new(args_mouse_up),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
             NativeInterrupt::ContextMenu(args) => {
-                let prospective_hit = engine
+                let topmost_node = engine
                     .runtime_context
                     .get_topmost_element_beneath_ray(Point2::new(args.x, args.y));
-                if let Some(topmost_node) = prospective_hit {
-                    let args_context_menu = ContextMenu {
-                        mouse: MouseEventArgs {
-                            x: args.x,
-                            y: args.y,
-                            button: MouseButton::from(args.button.clone()),
-                            modifiers: args
-                                .modifiers
-                                .iter()
-                                .map(|x| ModifierKey::from(x))
-                                .collect(),
-                        },
-                    };
-                    topmost_node.dispatch_context_menu(
-                        Event::new(args_context_menu),
-                        &globals,
-                        &engine.runtime_context,
-                    )
-                } else {
-                    false
-                }
+                let args_context_menu = ContextMenu {
+                    mouse: MouseEventArgs {
+                        x: args.x,
+                        y: args.y,
+                        button: MouseButton::from(args.button.clone()),
+                        modifiers: args
+                            .modifiers
+                            .iter()
+                            .map(|x| ModifierKey::from(x))
+                            .collect(),
+                    },
+                };
+                topmost_node.dispatch_context_menu(
+                    Event::new(args_context_menu),
+                    &globals,
+                    &engine.runtime_context,
+                )
             }
         };
 

--- a/pax-compiler/files/interfaces/web/src/events/listeners.ts
+++ b/pax-compiler/files/interfaces/web/src/events/listeners.ts
@@ -136,34 +136,6 @@ export function setupEventListeners(chassis: PaxChassisWeb) {
             evt.preventDefault();
         }
     }, true);
-    window.addEventListener('mouseover', (evt) => {
-        let event = {
-            "MouseOver": {
-                "x": evt.clientX,
-                "y": evt.clientY,
-                "button": getMouseButton(evt),
-                "modifiers": convertModifiers(evt)
-            }
-        };
-        let res = chassis.interrupt(JSON.stringify(event), []);
-        if (res.prevent_default) {
-            evt.preventDefault();
-        }
-    }, true);
-    window.addEventListener('mouseout', (evt) => {
-        let event = {
-            "MouseOut": {
-                "x": evt.clientX,
-                "y": evt.clientY,
-                "button": getMouseButton(evt),
-                "modifiers": convertModifiers(evt)
-            }
-        };
-        let res = chassis.interrupt(JSON.stringify(event), []);
-        if (res.prevent_default) {
-            evt.preventDefault();
-        }
-    }, true);
     window.addEventListener('contextmenu', (evt) => {
         let event = {
             "ContextMenu": {

--- a/pax-designer/src/controls/toolbar/mod.rs
+++ b/pax-designer/src/controls/toolbar/mod.rs
@@ -36,6 +36,7 @@ pub struct Toolbar {
 #[engine_import_path("pax_engine")]
 pub struct ToolbarItemView {
     pub background: bool,
+    pub tooltip: String,
     pub icon: String,
     pub more_than_one_item: bool,
     pub row: usize,
@@ -50,6 +51,7 @@ struct ToolbarEntry {
 
 struct ToolbarItem {
     icon: &'static str,
+    tooltip: &'static str,
     event: ToolbarEvent,
 }
 
@@ -88,10 +90,12 @@ thread_local! {
                 items: vec![
                     ToolbarItem {
                         icon: "assets/icons/icon-pointer-percent.png",
+                        tooltip: "Pointer Tool Percent",
                         event: ToolbarEvent::SelectTool(Tool::PointerPercent)
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-pointer-px.png",
+                        tooltip: "Pointer Tool Pixels",
                         event: ToolbarEvent::SelectTool(Tool::PointerPixels)
                     }
                 ]
@@ -112,10 +116,12 @@ thread_local! {
                 items: vec![
                     ToolbarItem {
                         icon: "assets/icons/icon-rectangle.png",
+                        tooltip: "Rectangle Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Rectangle))
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-ellipse.png",
+                        tooltip: "Ellipse Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Ellipse))
                     }
                 ]
@@ -124,6 +130,7 @@ thread_local! {
                 items: vec![
                     ToolbarItem {
                         icon: "assets/icons/icon-text.png",
+                        tooltip: "Text Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Text))
                     },
                 ]
@@ -132,10 +139,12 @@ thread_local! {
                 items: vec![
                     ToolbarItem {
                         icon: "assets/icons/icon-stacker.png",
+                        tooltip: "Stacker Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Stacker))
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-scroller.png",
+                        tooltip: "Scroller Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Scroller))
                     },
                 ]
@@ -144,26 +153,32 @@ thread_local! {
                 items: vec![
                     ToolbarItem {
                         icon: "assets/icons/icon-checkbox.png",
+                        tooltip: "Checkbox Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Checkbox))
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-textbox.png",
+                        tooltip: "Textbox Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Textbox))
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-button.png",
+                        tooltip: "Button Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Button))
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-slider.png",
+                        tooltip: "Slider Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Slider))
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-dropdown.png",
+                        tooltip: "Dropdown Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::Dropdown))
                     },
                     ToolbarItem {
                         icon: "assets/icons/icon-component.png",
+                        tooltip: "RadioSet Creation Tool",
                         event: ToolbarEvent::SelectTool(Tool::CreateComponent(Component::RadioSet))
                     },
                 ]
@@ -195,6 +210,7 @@ impl Toolbar {
                     let first = entry.items.first().unwrap();
                     ToolbarItemView {
                         background: false,
+                        tooltip: String::from(first.tooltip),
                         icon: String::from(first.icon),
                         more_than_one_item: entry.items.len() > 1,
                         row,
@@ -235,6 +251,7 @@ impl Toolbar {
                         .enumerate()
                         .map(|(col, item)| ToolbarItemView {
                             background: true,
+                            tooltip: String::from(item.tooltip),
                             icon: String::from(item.icon),
                             more_than_one_item: false,
                             row,
@@ -264,6 +281,7 @@ impl Toolbar {
                                         entries.update(|entries| {
                                             entries[row] = ToolbarItemView {
                                                 background: false,
+                                                tooltip: String::from(item.tooltip),
                                                 icon: String::from(item.icon),
                                                 more_than_one_item: entry.items.len() > 1,
                                                 row,

--- a/pax-designer/src/controls/toolbar/toolbar_item.pax
+++ b/pax-designer/src/controls/toolbar/toolbar_item.pax
@@ -3,7 +3,9 @@
     if self.data.more_than_one_item {
         <Image class=arrow source=ImageSource::Url("assets/icons/chevron-down.png") @click=self.dropdown/>
     }
-    <Image class=icon source={ImageSource::Url(self.data.icon)} @click=self.on_click/>
+    <Tooltip  @click=self.on_click tip={self.data.tooltip}>
+        <Image class=icon source={ImageSource::Url(self.data.icon)}/>
+    </Tooltip>
     if self.data.background {
         <Rectangle
             fill=rgb(12.5%, 12.5%, 12.5%)

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -68,8 +68,6 @@ pub enum NativeInterrupt {
     Wheel(WheelInterruptArgs),
     MouseDown(MouseDownInterruptArgs),
     MouseUp(MouseUpInterruptArgs),
-    MouseOver(MouseOverInterruptArgs),
-    MouseOut(MouseOutInterruptArgs),
     ContextMenu(ContextMenuInterruptArgs),
     Image(ImageLoadInterruptArgs),
     AddedLayer(AddedLayerArgs),

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -345,15 +345,11 @@ pub struct MouseUp {
 
 /// User moves the mouse onto an element.
 #[derive(Clone)]
-pub struct MouseOver {
-    pub mouse: MouseEventArgs,
-}
+pub struct MouseOver {}
 
 /// User moves the mouse away from an element.
 #[derive(Clone)]
-pub struct MouseOut {
-    pub mouse: MouseEventArgs,
-}
+pub struct MouseOut {}
 
 /// User right-clicks an element to open the context menu.
 #[derive(Clone)]

--- a/pax-runtime/src/engine/expanded_node.rs
+++ b/pax-runtime/src/engine/expanded_node.rs
@@ -711,8 +711,8 @@ impl ExpandedNode {
     dispatch_event_handler!(dispatch_mouse_down, MouseDown, MOUSE_DOWN_HANDLERS, true);
     dispatch_event_handler!(dispatch_mouse_up, MouseUp, MOUSE_UP_HANDLERS, true);
     dispatch_event_handler!(dispatch_mouse_move, MouseMove, MOUSE_MOVE_HANDLERS, true);
-    dispatch_event_handler!(dispatch_mouse_over, MouseOver, MOUSE_OVER_HANDLERS, true);
-    dispatch_event_handler!(dispatch_mouse_out, MouseOut, MOUSE_OUT_HANDLERS, true);
+    dispatch_event_handler!(dispatch_mouse_over, MouseOver, MOUSE_OVER_HANDLERS, false);
+    dispatch_event_handler!(dispatch_mouse_out, MouseOut, MOUSE_OUT_HANDLERS, false);
     dispatch_event_handler!(
         dispatch_double_click,
         DoubleClick,

--- a/pax-std/src/core/mod.rs
+++ b/pax-std/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod link;
 pub mod scrollbar;
 pub mod scroller;
 pub mod text;
+pub mod tooltip;
 
 //Only exposing inline_frame when designtime feature is enabled,
 //mostly as a safety measure to prevent it from being used in userland
@@ -23,3 +24,4 @@ pub use link::*;
 pub use scrollbar::*;
 pub use scroller::*;
 pub use text::*;
+pub use tooltip::*;

--- a/pax-std/src/core/tooltip.rs
+++ b/pax-std/src/core/tooltip.rs
@@ -1,0 +1,68 @@
+#[allow(unused)]
+use crate::*;
+use pax_engine::api::{Event, MouseOut};
+use pax_engine::api::{MouseOver, Property};
+use pax_engine::*;
+use pax_runtime::api::NodeContext;
+
+/// A scrolling container for arbitrary content.
+#[pax]
+#[engine_import_path("pax_engine")]
+#[inlined(
+    <Group >
+        <Rectangle fill=TRANSPARENT/>
+        for i in 0..self._slot_children_count {
+            slot(0)
+        }
+    </Group>
+    if self._showing {
+        <Group x={100% + 5px} y={100% + 5px} anchor_x=0% anchor_y=0% width=200px height=30px>
+            <Text x=5px height=100% width={100% -10px} id=text text={self.tip}/>
+            <Rectangle corner_radii={RectangleCornerRadii::radii(5.00, 5.00, 5.00, 5.00)} fill=rgb(12.5%, 12.5%, 12.5%)/>
+        </Group>
+    }
+    @settings {
+        @mouse_over: self.mouse_over
+        @mouse_out: self.mouse_out
+        @mount: on_mount
+        #text {
+            selectable: false,
+            style: {
+                    font: {Font::Web(
+                        "ff-real-headline-pro",
+                        "https://use.typekit.net/ivu7epf.css",
+                        FontStyle::Normal,
+                        FontWeight::ExtraLight,
+                    )},
+                    font_size: 16px,
+                    fill: WHITE,
+                    align_vertical: TextAlignVertical::Center,
+                    align_horizontal: TextAlignHorizontal::Left,
+                    align_multiline: TextAlignHorizontal::Center
+            }
+    	}
+    }
+
+)]
+pub struct Tooltip {
+    pub tip: Property<String>,
+    pub _showing: Property<bool>,
+    pub _slot_children_count: Property<usize>,
+}
+
+impl Tooltip {
+    pub fn on_mount(&mut self, ctx: &NodeContext) {
+        let slot_children_count = ctx.slot_children_count.clone();
+        let deps = [slot_children_count.untyped()];
+        self._slot_children_count
+            .replace_with(Property::computed(move || slot_children_count.get(), &deps));
+    }
+
+    pub fn mouse_over(&mut self, _ctx: &NodeContext, _event: Event<MouseOver>) {
+        self._showing.set(true);
+    }
+
+    pub fn mouse_out(&mut self, _ctx: &NodeContext, _event: Event<MouseOut>) {
+        self._showing.set(false);
+    }
+}


### PR DESCRIPTION
Mouse over/out now tracks a _single_ component at a time, and fires over/out whenever a new component is entered. Could be expanded in the future: this isn't as flexible as the DOM model that keeps track of this state for all nodes under the mouse.

+ Tooltip component added to the standard library.
+ Example use case added to the toolbar in the designer.