### PR TITLE
ci: Update to `actions/checkout@v4`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install sccache
       run: |


### PR DESCRIPTION
The older versions use a version of NodeJS that is deprecated within GitHub's infrastructure and results in a warning in the GitHub Actions UI.